### PR TITLE
DTM-1283 coverity issue 1

### DIFF
--- a/src/sec_security_openssl.c
+++ b/src/sec_security_openssl.c
@@ -5680,6 +5680,7 @@ Sec_Result SecProcessor_GetInfo(Sec_ProcessorHandle* secProcHandle,
 
     Sec_Memset(secProcInfo, 0x00, sizeof(Sec_ProcessorInfo));
     strncpy((char *)secProcInfo->version, SEC_API_VERSION, strlen(SEC_API_VERSION));
+    secProcInfo->version[strlen(SEC_API_VERSION)] = '\0';
 
     return SEC_RESULT_SUCCESS;
 }


### PR DESCRIPTION
Reason for change: terminate buffer with null

Test Procedure: build and pass coverity

Risks: Low

Signed-off-by: Kevin Huang <kevin_huang2@comcast.com>