### PR TITLE
DTM-1290 openssl coverity issue #8

### DIFF
--- a/src/sec_security_utils.c
+++ b/src/sec_security_utils.c
@@ -111,6 +111,7 @@ Sec_Result SecUtils_ReadFile(const char *path, void *data, SEC_SIZE data_len,
     FILE *f = NULL;
     Sec_Result sec_res = SEC_RESULT_SUCCESS;
     SEC_BYTE last_byte;
+    SEC_SIZE read = 0;
 
     *data_read = 0;
 
@@ -134,7 +135,7 @@ Sec_Result SecUtils_ReadFile(const char *path, void *data, SEC_SIZE data_len,
         goto cleanup;
     }
 
-    fread(&last_byte, 1, 1, f);
+    read= fread(&last_byte, 1, 1, f);
 
     if (0 == feof(f))
     {


### PR DESCRIPTION
Reason for change: ignored number of bytes read

Test procedure: build and pass coverity

Risks: low

Signed-off-by: Kevin Huang <kevin_huang2@comcast.com>