### PR TITLE
DTM-1291 openssl coverity issue #9

### DIFF
--- a/src/sec_security_asn1kc.c
+++ b/src/sec_security_asn1kc.c
@@ -747,12 +747,6 @@ Sec_Result SecAsn1KC_Encode(Sec_Asn1KC *kc, SEC_BYTE *buf, SEC_SIZE buf_len, SEC
       *written = i2d_Sec_Asn1KC(kc, &buf);
     }
 
-    if (*written < 0)
-    {
-        SEC_LOG_ERROR("der_encode_to_buffer failed");
-        return SEC_RESULT_FAILURE;
-    }
-
     return SEC_RESULT_SUCCESS;
 }
 

--- a/src/sec_security_asn1kc.c
+++ b/src/sec_security_asn1kc.c
@@ -737,6 +737,11 @@ Sec_Result SecAsn1KC_Encode(Sec_Asn1KC *kc, SEC_BYTE *buf, SEC_SIZE buf_len, SEC
     {
         *written = der_len;
     }
+    else if (der_len < 0)
+    {
+        SEC_LOG_ERROR("der_encode_to_buffer failed");
+        return SEC_RESULT_FAILURE;
+    }
     else if (der_len > buf_len)
     {
         SEC_LOG_ERROR("der_encode_to_buffer invalide buffer length, der_len = %d, buf_len = %d", der_len, buf_len);


### PR DESCRIPTION
Reason for change: unnecessary check of unsigned value < 0

Test Procedure: build and pass coverity

Risks: low

Signed-off-by: Kevin Huang <kevin_huang2@comcast.com>