### PR TITLE
DTM-1289 Sec API 2.3 Openssl Coverity Issue 7

### DIFF
--- a/src/sec_security_asn1kc.c
+++ b/src/sec_security_asn1kc.c
@@ -770,7 +770,7 @@ Sec_Asn1KC *SecAsn1KC_Decode(SEC_BYTE *buf, SEC_SIZE buf_len)
     }
     else if (buf_len > UINT32_MAX)
     {
-        EC_LOG_ERROR("der_encode_to_buffer failed");
+        SEC_LOG_ERROR("der_encode_to_buffer failed");
         return NULL;
     }
     

--- a/src/sec_security_openssl.c
+++ b/src/sec_security_openssl.c
@@ -4515,6 +4515,13 @@ static Sec_Result _ConcatKDF(Sec_ProcessorHandle* secProcHandle,
     Sec_Result res = SEC_RESULT_FAILURE;
 
     digest_length = SecDigest_GetDigestLenForAlgorithm(digestAlgorithm);
+
+    if(digest_length == 0)
+    {
+        SEC_LOG_ERROR("Invalid digest length");
+        goto done;
+    }
+
     r = out_key_length / digest_length + ((out_key_length % digest_length == 0) ? 0 : 1);
 
     for (i = 1; i <= r; ++i)


### PR DESCRIPTION
Reason for change: Resolve div by 0 coverity issue.

Test Procedure: Sec API unit test and Coverity Scan

Risks: Low

Signed-off-by: Joseph <Joseph_Hewitt@cable.comcast.com>